### PR TITLE
Adapt building of Pose2d messages to api.

### DIFF
--- a/reachy_sdk_server/reachy_sdk_server/conversion.py
+++ b/reachy_sdk_server/reachy_sdk_server/conversion.py
@@ -168,12 +168,12 @@ def joint_state_to_arm_position(js: JointState, arm: Part) -> ArmPosition:
 
     return ArmPosition(
         shoulder_position=Pose2d(
-            axis_1=js.position[0],
-            axis_2=js.position[1],
+            axis_1=FloatValue(value=js.position[0]),
+            axis_2=FloatValue(value=js.position[1]),
         ),
         elbow_position=Pose2d(
-            axis_1=js.position[2],
-            axis_2=js.position[3],
+            axis_1=FloatValue(value=js.position[2]),
+            axis_2=FloatValue(value=js.position[3]),
         ),
         wrist_position=extrinsic_euler_angles_as_rotation3d(
             roll=js.position[4],


### PR DESCRIPTION
There were issues when calling the inverse kinematics of the arm with the sdk client. It appears that building Pose2d messages from Orbita2d proto was not uptodate with the API (float were still used instead of FloatValue).

Tested with reachy2-sdk.