### PR TITLE
143 head orientation pb

### DIFF
--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -295,7 +295,9 @@ class GoToServicer:
 
         return GoToId(id=goal_id)
 
-    def goto_joints_from_quat(self, part_id: PartId, q: Tuple[float, float, float, float], duration: float, interpolation_mode: str) -> GoToId:
+    def goto_joints_from_quat(
+        self, part_id: PartId, q: Tuple[float, float, float, float], duration: float, interpolation_mode: str
+    ) -> GoToId:
         q = Quaternion(x=q_numpy[0], y=q_numpy[1], z=q_numpy[2], w=q_numpy[3])
         M = pose_matrix_from_quaternion(q)
         q0 = JointState()

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -298,8 +298,8 @@ class GoToServicer:
     def goto_joints_from_quat(
         self, part_id: PartId, q: Tuple[float, float, float, float], duration: float, interpolation_mode: str
     ) -> GoToId:
-        q = Quaternion(x=q_numpy[0], y=q_numpy[1], z=q_numpy[2], w=q_numpy[3])
-        M = pose_matrix_from_quaternion(q)
+        q_quat = Quaternion(x=q[0], y=q[1], z=q[2], w=q[3])
+        M = pose_matrix_from_quaternion(q_quat)
         q0 = JointState()
         q0.position = [0.0, 0.0, 0.0]
 


### PR DESCRIPTION
Quaternion and matrix commands now use ik to be in cartesian space and do not use joint space anymore

Tested using pytest from the sdk client branch 290: https://github.com/pollen-robotics/reachy2-sdk/pull/291