### PR TITLE
157 control hand in position

### DIFF
--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/hand.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/hand.py
@@ -146,9 +146,7 @@ class HandServicer:
             opening = self.position_to_opening(request.position.parallel_gripper.position.value)
         else:
             # This is a % of the opening
-            opening = np.clip(
-                request.position.parallel_gripper.opening_percentage.value, 0, 1
-            )  # qui est ce qui était déjà fait
+            opening = np.clip(request.position.parallel_gripper.opening_percentage.value, 0, 1)
 
         cmd = DynamicJointState()
         cmd.joint_names = []

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/hand.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/hand.py
@@ -142,8 +142,11 @@ class HandServicer:
     def SetHandPosition(self, request: HandPositionRequest, context: grpc.ServicerContext) -> Empty:
         hand = self.get_hand_part_from_part_id(request.id, context)
 
-        # This is a % of the opening
-        opening = np.clip(request.position.parallel_gripper.position, 0, 1)
+        if request.position.parallel_gripper.HasField("goal_position"):
+            opening = self.position_to_opening(request.position.parallel_gripper.goal_position)
+        else:
+            # This is a % of the opening
+            opening = np.clip(request.position.parallel_gripper.opening_percentage, 0, 1)  # qui est ce qui était déjà fait
 
         cmd = DynamicJointState()
         cmd.joint_names = []


### PR DESCRIPTION
Possibility to send goal_position to gripper instead of opening.

To be used with: 
- reachy2-sdk-api : https://github.com/pollen-robotics/reachy2-sdk-api/pull/134
- reachy2-sdk : https://github.com/pollen-robotics/reachy2-sdk/pull/342

Can be used doing : 
```python
reachy.r_arm.gripper.goal_position = 40
reachy.send_goal_positions()
```

Tested using unit tests of the sdk client (on https://github.com/pollen-robotics/reachy2-sdk/pull/342)