### PR TITLE
Update topic name for cmd_vel

### DIFF
--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/mobile_base.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/mobile_base.py
@@ -102,7 +102,7 @@ class MobileBaseServicer(
             self.mobile_base_enabled = False
             return
 
-        self.cmd_vel_pub = self.bridge_node.create_publisher(Twist, "cmd_vel_zuuu", 10)
+        self.cmd_vel_pub = self.bridge_node.create_publisher(Twist, "cmd_vel", 10)
 
         self.bridge = CvBridge()
         self.lidar_img_subscriber = self.bridge_node.create_subscription(Image, "lidar_image", self.get_lidar_img, 1)


### PR DESCRIPTION
Topic name was changed to "cmd_vel_zuuu" for publishing, but there was no subscriber to this topic.
Coming back to "cmd_vel" (seems to work both in gazebo and real)