### PR TITLE
210 add antennas

### DIFF
--- a/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
+++ b/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
@@ -492,7 +492,7 @@ class AbstractBridgeNode(Node):
 
         goal_handle = await self.goto_zuuu_action_client.send_goal_async(goal_msg, feedback_callback=feedback_callback)
 
-        self.get_logger().warning("zuuu goto feedback_callback setuped")
+        self.get_logger().debug("zuuu goto feedback_callback setuped")
 
         if not goal_handle.accepted:
             self.get_logger().warning("zuuu goto Goal rejected!")
@@ -523,7 +523,7 @@ class AbstractBridgeNode(Node):
         cmd.joint_names = []
 
         for name in self.joint_names:
-            if name.startswith(joint_prefix):
+            if name.startswith(joint_prefix) or (joint_prefix == "neck" and name.startswith("antenna")):
                 # Note: any string starts with the empty string
                 component = self.components.get_by_name(name)
                 if "position" in component.state and "target_position" in component.state:

--- a/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
+++ b/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
@@ -2,7 +2,7 @@ from asyncio.events import AbstractEventLoop
 from collections import deque
 from functools import partial
 from threading import Event, Lock
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import prometheus_client as pc
@@ -391,8 +391,10 @@ class AbstractBridgeNode(Node):
         joint_names: List[str],
         goal_pose: np.array,
         duration: float,
-        mode: str = "minimum_jerk",  # "linear" or "minimum_jerk"
+        mode: str = "minimum_jerk",  # "linear", "minimum_jerk" or "elliptical"
         sampling_freq: float = 150.0,
+        arc_direction: Optional[str] = None,
+        secondary_radius: Optional[float] = None,
         feedback_callback=None,
         return_handle=False,
     ):
@@ -410,6 +412,11 @@ class AbstractBridgeNode(Node):
 
         request.goal_pose = PoseStamped()
         request.goal_pose.pose = matrix_to_pose(goal_pose)
+
+        if arc_direction is not None:
+            request.arc_direction = arc_direction
+        if secondary_radius is not None:
+            request.secondary_radius = secondary_radius
 
         self.get_logger().debug("Sending goal request...")
 

--- a/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
+++ b/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
@@ -350,8 +350,6 @@ class AbstractBridgeNode(Node):
         feedback_callback=None,
         return_handle=False,
     ):
-        self.logger.error("in send_goto_goal")
-
         goal_msg = Goto.Goal()
         request = goal_msg.request  # This is of type pollen_msgs/GotoRequest
 
@@ -367,16 +365,16 @@ class AbstractBridgeNode(Node):
         request.goal_joints.velocity = goal_velocities
         request.goal_joints.effort = []  # Not implemented for now
 
-        self.get_logger().error("Sending goal request...")
+        self.get_logger().debug("Sending goal request...")
 
         goal_handle = await self.goto_action_client[part].send_goal_async(goal_msg, feedback_callback=feedback_callback)
-        self.get_logger().error("feedback_callback setuped")
+        self.get_logger().debug("feedback_callback setuped")
 
         if not goal_handle.accepted:
             self.get_logger().warning("Goal rejected!")
             return None
 
-        self.get_logger().error("Goal accepted")
+        self.get_logger().debug("Goal accepted")
 
         if return_handle:
             return goal_handle
@@ -384,7 +382,7 @@ class AbstractBridgeNode(Node):
             res = await goal_handle.get_result_async()
             result = res.result
             status = res.status
-            self.get_logger().error(f"Goto finished. Result: {result.result.status}")
+            self.get_logger().debug(f"Goto finished. Result: {result.result.status}")
             return result, status
 
     async def send_goto_cartesian_goal(
@@ -398,8 +396,6 @@ class AbstractBridgeNode(Node):
         feedback_callback=None,
         return_handle=False,
     ):
-        self.get_logger().error("In bridge node send_goto_cartesian_goal")
-
         goal_msg = Goto.Goal()
         request = goal_msg.request  # This is of type pollen_msgs/GotoRequest
 
@@ -415,16 +411,16 @@ class AbstractBridgeNode(Node):
         request.goal_pose = PoseStamped()
         request.goal_pose.pose = matrix_to_pose(goal_pose)
 
-        self.get_logger().error("Sending goal request...")
+        self.get_logger().debug("Sending goal request...")
 
         goal_handle = await self.goto_action_client[part].send_goal_async(goal_msg, feedback_callback=feedback_callback)
-        self.get_logger().error("feedback_callback setuped")
+        self.get_logger().debug("feedback_callback setuped")
 
         if not goal_handle.accepted:
             self.get_logger().warning("Goal rejected!")
             return None
 
-        self.get_logger().error("Goal accepted")
+        self.get_logger().debug("Goal accepted")
 
         if return_handle:
             return goal_handle

--- a/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
+++ b/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
@@ -350,10 +350,13 @@ class AbstractBridgeNode(Node):
         feedback_callback=None,
         return_handle=False,
     ):
+        self.logger.error("in send_goto_goal")
+
         goal_msg = Goto.Goal()
         request = goal_msg.request  # This is of type pollen_msgs/GotoRequest
 
         request.duration = duration
+        request.interpolation_space = "joints"
         request.mode = mode
         request.sampling_freq = sampling_freq
         request.safety_on = False
@@ -364,16 +367,16 @@ class AbstractBridgeNode(Node):
         request.goal_joints.velocity = goal_velocities
         request.goal_joints.effort = []  # Not implemented for now
 
-        self.get_logger().debug("Sending goal request...")
+        self.get_logger().error("Sending goal request...")
 
         goal_handle = await self.goto_action_client[part].send_goal_async(goal_msg, feedback_callback=feedback_callback)
-        self.get_logger().debug("feedback_callback setuped")
+        self.get_logger().error("feedback_callback setuped")
 
         if not goal_handle.accepted:
             self.get_logger().warning("Goal rejected!")
             return None
 
-        self.get_logger().debug("Goal accepted")
+        self.get_logger().error("Goal accepted")
 
         if return_handle:
             return goal_handle
@@ -381,12 +384,13 @@ class AbstractBridgeNode(Node):
             res = await goal_handle.get_result_async()
             result = res.result
             status = res.status
-            self.get_logger().debug(f"Goto finished. Result: {result.result.status}")
+            self.get_logger().error(f"Goto finished. Result: {result.result.status}")
             return result, status
 
     async def send_goto_cartesian_goal(
         self,
         part: str,
+        joint_names: List[str],
         goal_pose: np.array,
         duration: float,
         mode: str = "minimum_jerk",  # "linear" or "minimum_jerk"
@@ -400,11 +404,15 @@ class AbstractBridgeNode(Node):
         request = goal_msg.request  # This is of type pollen_msgs/GotoRequest
 
         request.duration = duration
+        request.interpolation_space = "cartesian"
         request.mode = mode
         request.sampling_freq = sampling_freq
         request.safety_on = False
 
-        request.goal_pose = IKRequest()
+        request.goal_joints = JointState()
+        request.goal_joints.name = joint_names
+
+        request.goal_pose = PoseStamped()
         request.goal_pose.pose = matrix_to_pose(goal_pose)
 
         self.get_logger().error("Sending goal request...")

--- a/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
+++ b/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
@@ -137,7 +137,7 @@ class AbstractBridgeNode(Node):
         self.control_mode = "NONE_CONTROL_MODE"
 
         # Setup goto action clients
-        self.prefixes = ["r_arm", "l_arm", "neck"]
+        self.prefixes = ["r_arm", "l_arm", "neck", "antenna_right", "antenna_left"]
         self.goto_action_client = {}
         for prefix in self.prefixes:
             self.goto_action_client[prefix] = ActionClient(self, Goto, f"{prefix}_goto")

--- a/reachy_sdk_server/reachy_sdk_server/conversion.py
+++ b/reachy_sdk_server/reachy_sdk_server/conversion.py
@@ -146,7 +146,8 @@ def neck_rotation_to_joint_state(rot: Rotation3d, head: Part) -> JointState:
     js = JointState()
 
     for c in head.components:
-        js.name.extend(c.get_all_joints())
+        if c.type == "orbita3d":
+            js.name.extend(c.get_all_joints())
 
     neck_pos = rotation3d_as_extrinsinc_euler_angles(rot)
 

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -802,7 +802,6 @@ class GoToServicer:
         self.logger.info(f"Removing all gotos goals for {part_name}")
 
         for goal_id in part_goal_ids:
-            self.logger.info(f"Cancelling goal_id {goal_id}")
             self.cancel_goal_by_goal_id(goal_id)
 
     def cancel_all_goals(self) -> None:

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -832,10 +832,10 @@ class GoToServicer:
 
         if goal_id in self.goal_manager.antenna_right_goal:
             part = self.bridge_node.parts.get_by_name("head")
-            component = self.bridge_node.components.get_by_name("antenna_right")
+            component = part.components_dict["antenna_right"]
         elif goal_id in self.goal_manager.antenna_left_goal:
             part = self.bridge_node.parts.get_by_name("head")
-            component = self.bridge_node.components.get_by_name("antenna_left")
+            component = part.components_dict["antenna_left"]
         if part is not None:
             mode = self._get_grpc_interpolation_mode(goal_request["mode"])
             duration = goal_request["duration"]

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -195,7 +195,10 @@ class GoToServicer:
                     if request.elliptical_parameters.HasField("secondary_radius"):
                         secondary_radius = request.elliptical_parameters.secondary_radius.value
                     else:
-                        secondary_radius = None
+                        secondary_radius = -1.0
+                else:
+                    arc_direction = None
+                    secondary_radius = -1.0
 
                 return self.goto_cartesian(
                     arm.name,

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -634,6 +634,25 @@ class GoToServicer:
             )
             return None
 
+    def _get_grpc_arc_direction(self, arc_direction: str) -> ArcDirection:
+        if arc_direction == "above":
+            return ArcDirection.ABOVE
+        elif arc_direction == "below":
+            return ArcDirection.BELOW
+        elif arc_direction == "left":
+            return ArcDirection.LEFT
+        elif arc_direction == "right":
+            return ArcDirection.RIGHT
+        elif arc_direction == "front":
+            return ArcDirection.FRONT
+        elif arc_direction == "back":
+            return ArcDirection.BACK
+        else:
+            self.logger.error(
+                f"Arc direction {arc_direction} not supported. Should be one of 'above', 'below', 'front', 'back', 'right' or 'left'."
+            )
+            return None
+
     def get_part_queue(self, part_name: str) -> GoToQueue:
         goal_ids_int = getattr(self.goal_manager, part_name + "_goal")
         goal_ids = [
@@ -706,7 +725,7 @@ class GoToServicer:
                 }
 
                 if goal_request["mode"] == "elliptical":
-                    arc_direction = self._get_arc_direction(goal_request["arc_direction"])
+                    arc_direction = self._get_grpc_arc_direction(goal_request["arc_direction"])
                     secondary_radius = goal_request["secondary_radius"]
                     elliptical_parameters = EllipticalGoToParameters(
                         arc_direction=arc_direction,
@@ -714,7 +733,6 @@ class GoToServicer:
                     )
                     req_params["elliptical_parameters"] = elliptical_parameters
 
-                # request = GoToRequest(**req_params)
                 request = GoToRequest(**req_params)
 
             else:

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -349,7 +349,7 @@ class GoToServicer:
                 )
         elif request.joints_goal.HasField("antenna_joint_goal"):
             antenna_joint_goal = request.joints_goal.antenna_joint_goal
-            antenna= self.bridge_node.components.get_by_name(antenna_joint_goal.antenna.id.name)
+            antenna = self.bridge_node.components.get_by_name(antenna_joint_goal.antenna.id.name)
             duration = antenna_joint_goal.duration.value
             joint_names = [antenna_joint_goal.antenna.id.name]
             goal_positions = [antenna_joint_goal.joint_goal.value]
@@ -389,7 +389,6 @@ class GoToServicer:
 
     def GetPartGoToPlaying(self, part_id: PartId, context: grpc.ServicerContext) -> GoToId:
         part_name = self.get_part_by_part_id(part_id, context)
-        self.logger.error(f"GetPartGoToPlaying: {part_name}")
         return self.get_element_goto_playing(part_name.name)
 
     def GetPartGoToQueue(self, part_id: PartId, context: grpc.ServicerContext) -> GoToQueue:
@@ -403,7 +402,6 @@ class GoToServicer:
 
     def GetComponentGoToPlaying(self, component_id: ComponentId, context: grpc.ServicerContext) -> GoToId:
         component_name = self.get_component_by_component_id(component_id, context)
-        self.logger.error(f"GetPartGoToPlaying: {component_name}")
         return self.get_element_goto_playing(component_name.name)
 
     def GetComponentGoToQueue(self, component_id: ComponentId, context: grpc.ServicerContext) -> GoToQueue:
@@ -496,10 +494,6 @@ class GoToServicer:
 
         if part_name == "neck":
             part_name = "head"
-        if part_name == "antenna_right":
-            part_name = "r_antenna"
-        if part_name == "antenna_left":
-            part_name = "l_antenna"
         goal_id = self.goal_manager.store_goal_handle(part_name, goal_handle, goal_request)
 
         return GoToId(id=goal_id)
@@ -555,7 +549,6 @@ class GoToServicer:
         """Sends an action request to the mobile base goto action server in an async (non-blocking) way.
         The goal handle is then stored for future use and monitoring.
         """
-        self.logger.info(f"XXXXX Sending ZuuuGotoGoal request to mobile base")
         future = asyncio.run_coroutine_threadsafe(
             self.bridge_node.send_zuuu_goto_goal(
                 x_goal,
@@ -837,10 +830,10 @@ class GoToServicer:
 
             return request
 
-        if goal_id in self.goal_manager.r_antenna_goal:
+        if goal_id in self.goal_manager.antenna_right_goal:
             part = self.bridge_node.parts.get_by_name("head")
             component = self.bridge_node.components.get_by_name("antenna_right")
-        elif goal_id in self.goal_manager.l_antenna_goal:
+        elif goal_id in self.goal_manager.antenna_left_goal:
             part = self.bridge_node.parts.get_by_name("head")
             component = self.bridge_node.components.get_by_name("antenna_left")
         if part is not None:
@@ -906,8 +899,8 @@ class GoalManager:
         self.l_arm_goal = []
         self.head_goal = []
         self.mobile_base_goal = []
-        self.l_antenna_goal = []
-        self.r_antenna_goal = []
+        self.antenna_left_goal = []
+        self.antenna_right_goal = []
         self.goal_id_counter = 0
         self.lock = threading.Lock()
         self._hoarder_collector = threading.Thread(target=self._sort_goal_handles, daemon=True)

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -66,6 +66,14 @@ class GoToServicer:
 
         return part
 
+    def get_component_by_component_id(self, component_id: ComponentId, context: grpc.ServicerContext) -> Optional[Part]:
+        component = self.bridge_node.components.get_by_component_id(component_id)
+
+        if component is None:
+            context.abort(grpc.StatusCode.NOT_FOUND, f"Component not found (id={component_id}).")
+
+        return component
+
     def get_arm_part_by_part_id(self, part_id: PartId, context: grpc.ServicerContext) -> Part:
         part = self.bridge_node.parts.get_by_part_id(part_id)
 
@@ -381,15 +389,30 @@ class GoToServicer:
 
     def GetPartGoToPlaying(self, part_id: PartId, context: grpc.ServicerContext) -> GoToId:
         part_name = self.get_part_by_part_id(part_id, context)
-        return self.get_part_goto_playing(part_name.name)
+        self.logger.error(f"GetPartGoToPlaying: {part_name}")
+        return self.get_element_goto_playing(part_name.name)
 
     def GetPartGoToQueue(self, part_id: PartId, context: grpc.ServicerContext) -> GoToQueue:
         part_name = self.get_part_by_part_id(part_id, context)
-        return self.get_part_queue(part_name.name)
+        return self.get_element_queue(part_name.name)
 
     def CancelPartAllGoTo(self, part_id: PartId, context: grpc.ServicerContext) -> GoToAck:
         part_name = self.get_part_by_part_id(part_id, context)
-        self.cancel_part_all_goals(part_name.name)
+        self.cancel_element_all_goals(part_name.name)
+        return GoToAck(ack=True)
+
+    def GetComponentGoToPlaying(self, component_id: ComponentId, context: grpc.ServicerContext) -> GoToId:
+        component_name = self.get_component_by_component_id(component_id, context)
+        self.logger.error(f"GetPartGoToPlaying: {component_name}")
+        return self.get_element_goto_playing(component_name.name)
+
+    def GetComponentGoToQueue(self, component_id: ComponentId, context: grpc.ServicerContext) -> GoToQueue:
+        component_name = self.get_component_by_component_id(component_id, context)
+        return self.get_element_queue(component_name.name)
+
+    def CancelComponentAllGoTo(self, component_id: ComponentId, context: grpc.ServicerContext) -> GoToAck:
+        component_name = self.get_component_by_component_id(component_id, context)
+        self.cancel_element_all_goals(component_name.name)
         return GoToAck(ack=True)
 
     def goto_cartesian(
@@ -673,8 +696,8 @@ class GoToServicer:
             )
             return None
 
-    def get_part_queue(self, part_name: str) -> GoToQueue:
-        goal_ids_int = getattr(self.goal_manager, part_name + "_goal")
+    def get_element_queue(self, element_name: str) -> GoToQueue:
+        goal_ids_int = getattr(self.goal_manager, element_name + "_goal")
         goal_ids = [
             GoToId(id=goal_id_int)
             for goal_id_int in goal_ids_int
@@ -682,8 +705,8 @@ class GoToServicer:
         ]
         return GoToQueue(goto_ids=goal_ids)
 
-    def get_part_goto_playing(self, part_name: str) -> GoToId:
-        goal_ids = getattr(self.goal_manager, part_name + "_goal")
+    def get_element_goto_playing(self, element_name: str) -> GoToId:
+        goal_ids = getattr(self.goal_manager, element_name + "_goal")
         for goal_id in goal_ids:
             if goal_id in self.goal_manager.goal_handles and self.goal_manager.goal_handles[goal_id].status == 2:
                 return GoToId(id=goal_id)
@@ -862,11 +885,11 @@ class GoToServicer:
         else:
             return False
 
-    def cancel_part_all_goals(self, part_name: str) -> None:
-        part_goal_ids = getattr(self.goal_manager, part_name + "_goal")
-        self.logger.info(f"Removing all gotos goals for {part_name}")
+    def cancel_element_all_goals(self, element_name: str) -> None:
+        element_goal_ids = getattr(self.goal_manager, element_name + "_goal")
+        self.logger.info(f"Removing all gotos goals for {element_name}")
 
-        for goal_id in part_goal_ids:
+        for goal_id in element_goal_ids:
             self.cancel_goal_by_goal_id(goal_id)
 
     def cancel_all_goals(self) -> None:

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -188,8 +188,6 @@ class GoToServicer:
                     joint_names.extend(c.get_all_joints())
 
                 goal_pose = np.reshape(arm_cartesian_goal.goal_pose.data, (4, 4))
-                self.logger.error(f"goal_pose: {goal_pose}")
-                self.logger.error(f"joint_names: {joint_names}")
 
                 return self.goto_cartesian(
                     arm.name,
@@ -222,7 +220,7 @@ class GoToServicer:
         """This function can be called for an arm or the neck.
         In both cases, a goto_joints_space is performed to reach the goal positions in joint space.
         """
-        self.logger.error(f"GoToJoints: {request}")
+        self.logger.debug(f"GoToJoints: {request}")
         interpolation_mode = self.get_interpolation_mode(request)
         if not interpolation_mode:
             return GoToId(id=-1)
@@ -369,9 +367,6 @@ class GoToServicer:
         """Sends an action request to the goto action server in an async (non-blocking) way.
         The goal handle is then stored for future use and monitoring.
         """
-
-        self.logger.error("In Goto_cartesian")
-
         future = asyncio.run_coroutine_threadsafe(
             self.bridge_node.send_goto_cartesian_goal(
                 part_name,
@@ -408,8 +403,6 @@ class GoToServicer:
         """Sends an action request to the goto action server in an async (non-blocking) way.
         The goal handle is then stored for future use and monitoring.
         """
-        self.logger.error("in goto_joints_space")
-
         future = asyncio.run_coroutine_threadsafe(
             self.bridge_node.send_goto_goal(
                 part_name,
@@ -557,7 +550,7 @@ class GoToServicer:
                 f"Interpolation mode {interpolation_mode} not supported. Should be one of 'linear' or 'minimum_jerk'."
             )
             return None
-    
+
     def get_interpolation_space(self, request: GoToRequest) -> str:
         interpolation_space = request.interpolation_space.interpolation_space
         if interpolation_space == InterpolationSpace.JOINTS:

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/goto.py
@@ -346,7 +346,6 @@ class GoToServicer:
             joint_names = [antenna_joint_goal.antenna.id.name]
             goal_positions = [antenna_joint_goal.joint_goal.value]
 
-            self.logger.error("Coucou")
             return self.goto_joints_space(
                 antenna.name,
                 joint_names,
@@ -446,8 +445,6 @@ class GoToServicer:
         """Sends an action request to the goto action server in an async (non-blocking) way.
         The goal handle is then stored for future use and monitoring.
         """
-        self.logger.error("goto_joints_space")
-        self.logger.error(f"part {part_name}")
         future = asyncio.run_coroutine_threadsafe(
             self.bridge_node.send_goto_goal(
                 part_name,

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/head.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/head.py
@@ -219,6 +219,21 @@ class HeadServicer:
                 )
             )
 
+        dxl_motors = [
+            self.bridge_node.components.get_by_name("antenna_left"),
+            self.bridge_node.components.get_by_name("antenna_right"),
+        ]
+
+        for dxl in dxl_motors:
+            if dxl is not None:
+                cmd.joint_names.append(dxl.name)
+                cmd.interface_values.append(
+                    InterfaceValue(
+                        interface_names=["torque"],
+                        values=[torque],
+                    )
+                )
+
         self.bridge_node.publish_command(cmd)
 
     def TurnOn(self, request: PartId, context: grpc.ServicerContext) -> Empty:

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/head.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/head.py
@@ -110,14 +110,14 @@ class HeadServicer:
             l_antenna_state=self.dynamixel_servicer.GetState(
                 DynamixelMotorStateRequest(
                     fields=self.dynamixel_servicer.default_fields,
-                    id=ComponentId(id=self.bridge_node.components.get_by_name("antenna_left").id),
+                    id=ComponentId(id=head.components_dict["antenna_left"].id),
                 ),
                 context,
             ),
             r_antenna_state=self.dynamixel_servicer.GetState(
                 DynamixelMotorStateRequest(
                     fields=self.dynamixel_servicer.default_fields,
-                    id=ComponentId(id=self.bridge_node.components.get_by_name("antenna_right").id),
+                    id=ComponentId(id=head.components_dict["antenna_right"].id),
                 ),
                 context,
             ),
@@ -219,21 +219,6 @@ class HeadServicer:
                 )
             )
 
-        dxl_motors = [
-            self.bridge_node.components.get_by_name("antenna_left"),
-            self.bridge_node.components.get_by_name("antenna_right"),
-        ]
-
-        for dxl in dxl_motors:
-            if dxl is not None:
-                cmd.joint_names.append(dxl.name)
-                cmd.interface_values.append(
-                    InterfaceValue(
-                        interface_names=["torque"],
-                        values=[torque],
-                    )
-                )
-
         self.bridge_node.publish_command(cmd)
 
     def TurnOn(self, request: PartId, context: grpc.ServicerContext) -> Empty:
@@ -281,15 +266,16 @@ class HeadServicer:
             cmd.joint_names = []
 
             for c in part.components:
-                for i in range(1, 4):
-                    cmd.joint_names.append(f"{c.name}_raw_motor_{i}")
+                if c.type == "orbita3d":
+                    for i in range(1, 4):
+                        cmd.joint_names.append(f"{c.name}_raw_motor_{i}")
 
-                    cmd.interface_values.append(
-                        InterfaceValue(
-                            interface_names=["speed_limit"],
-                            values=[request.limit / 100],
+                        cmd.interface_values.append(
+                            InterfaceValue(
+                                interface_names=["speed_limit"],
+                                values=[request.limit / 100],
+                            )
                         )
-                    )
 
             self.bridge_node.publish_command(cmd)
         return Empty()
@@ -303,15 +289,16 @@ class HeadServicer:
             cmd.joint_names = []
 
             for c in part.components:
-                for i in range(1, 4):
-                    cmd.joint_names.append(f"{c.name}_raw_motor_{i}")
+                if c.type == "orbita3d":
+                    for i in range(1, 4):
+                        cmd.joint_names.append(f"{c.name}_raw_motor_{i}")
 
-                    cmd.interface_values.append(
-                        InterfaceValue(
-                            interface_names=["torque_limit"],
-                            values=[request.limit / 100],
+                        cmd.interface_values.append(
+                            InterfaceValue(
+                                interface_names=["torque_limit"],
+                                values=[request.limit / 100],
+                            )
                         )
-                    )
 
             self.bridge_node.publish_command(cmd)
         return Empty()

--- a/reachy_sdk_server/reachy_sdk_server/parts.py
+++ b/reachy_sdk_server/reachy_sdk_server/parts.py
@@ -99,6 +99,8 @@ class PartsHolder:
             return "arm"
         elif part_name == "head" and set(part_config.keys()) == {
             "neck",
+            "l_antenna",
+            "r_antenna",
         }:
             return "head"
         elif part_name.endswith("_hand"):


### PR DESCRIPTION
We now can call gotos with antennas, such as: 
`reachy.head.r_antenna.goto(50, duration=1)`  
`reachy.head.l_antenna.goto(-20, duration=0.2, interpolation_mode='linear', wait=True)`

Turning on the head on the robot also turns on the antennas

See https://github.com/pollen-robotics/reachy2-sdk/pull/505 for tests examples

Note: this PR is based on modifications of #207 