### PR TITLE
237 add access to item poses in mujoco scenes

### DIFF
--- a/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
+++ b/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
@@ -136,6 +136,15 @@ class AbstractBridgeNode(Node):
         self.zuuu_mode = "NONE_ZUUU_MODE"
         self.control_mode = "NONE_CONTROL_MODE"
 
+        # create a subscriber to the Mujoco objects poses
+        self.mujoco_objects_poses: dict = {}
+        self.create_subscription(
+            msg_type=PoseStamped,
+            topic="/mujoco/item_position",
+            callback=self.update_mujoco_object_pose,
+            qos_profile=10,
+        )
+
         # Setup goto action clients
         self.prefixes = ["r_arm", "l_arm", "neck", "r_hand", "l_hand", "antenna_right", "antenna_left"]
         self.goto_action_client = {}
@@ -244,6 +253,11 @@ class AbstractBridgeNode(Node):
             self.logger.error("No safety status received yet.")
             return {"safety_on": False, "safety_distance": 0.0, "critical_distance": 0.0, "status": 0}
         return self.lidar_safety
+    
+    # callback function for the /mujoco/item_position topic
+    def update_mujoco_object_pose(self, msg: PoseStamped) -> None:
+        matrix = pose_to_matrix(msg.pose)
+        self.mujoco_objects_poses[msg.header.frame_id] = matrix
 
     def publish_command(self, msg: DynamicJointState) -> None:
         self.joint_command_pub.publish(msg)

--- a/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
+++ b/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
@@ -253,7 +253,7 @@ class AbstractBridgeNode(Node):
             self.logger.error("No safety status received yet.")
             return {"safety_on": False, "safety_distance": 0.0, "critical_distance": 0.0, "status": 0}
         return self.lidar_safety
-    
+
     # callback function for the /mujoco/item_position topic
     def update_mujoco_object_pose(self, msg: PoseStamped) -> None:
         matrix = pose_to_matrix(msg.pose)

--- a/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
+++ b/reachy_sdk_server/reachy_sdk_server/abstract_bridge_node.py
@@ -257,7 +257,8 @@ class AbstractBridgeNode(Node):
     # callback function for the /mujoco/item_position topic
     def update_mujoco_object_pose(self, msg: PoseStamped) -> None:
         matrix = pose_to_matrix(msg.pose)
-        self.mujoco_objects_poses[msg.header.frame_id] = matrix
+        matrix_list = matrix.flatten().astype(float).tolist()
+        self.mujoco_objects_poses[msg.header.frame_id] = matrix_list
 
     def publish_command(self, msg: DynamicJointState) -> None:
         self.joint_command_pub.publish(msg)

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/joint_server.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/joint_server.py
@@ -17,6 +17,7 @@ from .goto import GoToServicer
 from .hand import HandServicer
 from .head import HeadServicer
 from .mobile_base import MobileBaseServicer
+from .mujoco import MujocoServicer
 from .orbita2d import Orbita2dServicer
 from .orbita3d import Orbita3dServicer
 from .reachy import ReachyServicer
@@ -78,18 +79,36 @@ class ReachyGRPCJointSDKServicer:
             core_mode,
         )
 
-        self.services = [
-            arm_servicer,
-            dynamixel_motor_servicer,
-            goto_servicer,
-            hand_servicer,
-            head_servicer,
-            mobile_base_servicer,
-            orbita2d_servicer,
-            orbita3d_servicer,
-            reachy_servicer,
-            tripod_servicer,
-        ]
+        if core_mode == ReachyCoreMode.MUJOCO:
+            mujoco_servicer = MujocoServicer(self.bridge_node, self.logger)
+
+            self.services = [
+                arm_servicer,
+                dynamixel_motor_servicer,
+                goto_servicer,
+                hand_servicer,
+                head_servicer,
+                mobile_base_servicer,
+                orbita2d_servicer,
+                orbita3d_servicer,
+                reachy_servicer,
+                tripod_servicer,
+                mujoco_servicer,
+            ]
+
+        else:
+            self.services = [
+                arm_servicer,
+                dynamixel_motor_servicer,
+                goto_servicer,
+                hand_servicer,
+                head_servicer,
+                mobile_base_servicer,
+                orbita2d_servicer,
+                orbita3d_servicer,
+                reachy_servicer,
+                tripod_servicer,
+            ]
 
         self.logger.info("Reachy GRPC Joint SDK Servicer initialized.")
 

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/joint_server.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/joint_server.py
@@ -80,17 +80,17 @@ class ReachyGRPCJointSDKServicer:
         )
 
         self.services = [
-                arm_servicer,
-                dynamixel_motor_servicer,
-                goto_servicer,
-                hand_servicer,
-                head_servicer,
-                mobile_base_servicer,
-                orbita2d_servicer,
-                orbita3d_servicer,
-                reachy_servicer,
-                tripod_servicer,
-            ]
+            arm_servicer,
+            dynamixel_motor_servicer,
+            goto_servicer,
+            hand_servicer,
+            head_servicer,
+            mobile_base_servicer,
+            orbita2d_servicer,
+            orbita3d_servicer,
+            reachy_servicer,
+            tripod_servicer,
+        ]
 
         if core_mode == ReachyCoreMode.MUJOCO:
             mujoco_servicer = MujocoServicer(self.bridge_node, self.logger)

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/joint_server.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/joint_server.py
@@ -79,36 +79,22 @@ class ReachyGRPCJointSDKServicer:
             core_mode,
         )
 
+        self.services = [
+                arm_servicer,
+                dynamixel_motor_servicer,
+                goto_servicer,
+                hand_servicer,
+                head_servicer,
+                mobile_base_servicer,
+                orbita2d_servicer,
+                orbita3d_servicer,
+                reachy_servicer,
+                tripod_servicer,
+            ]
+
         if core_mode == ReachyCoreMode.MUJOCO:
             mujoco_servicer = MujocoServicer(self.bridge_node, self.logger)
-
-            self.services = [
-                arm_servicer,
-                dynamixel_motor_servicer,
-                goto_servicer,
-                hand_servicer,
-                head_servicer,
-                mobile_base_servicer,
-                orbita2d_servicer,
-                orbita3d_servicer,
-                reachy_servicer,
-                tripod_servicer,
-                mujoco_servicer,
-            ]
-
-        else:
-            self.services = [
-                arm_servicer,
-                dynamixel_motor_servicer,
-                goto_servicer,
-                hand_servicer,
-                head_servicer,
-                mobile_base_servicer,
-                orbita2d_servicer,
-                orbita3d_servicer,
-                reachy_servicer,
-                tripod_servicer,
-            ]
+            self.services.append(mujoco_servicer)
 
         self.logger.info("Reachy GRPC Joint SDK Servicer initialized.")
 

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/mujoco.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/mujoco.py
@@ -1,0 +1,44 @@
+import os
+from typing import Iterator
+
+import grpc
+import rclpy
+import reachy2_sdk_api
+
+from google.protobuf.empty_pb2 import Empty
+from reachy2_sdk_api.reachy_pb2 import (
+    ReachyCoreMode,
+)
+from reachy2_sdk_api.mujoco_pb2 import (
+    MujocoObjectPose,
+    MujocoObjectsPoses,
+)
+
+from reachy2_sdk_api.mujoco_pb2_grpc import add_MujocoServiceServicer_to_server
+
+from ..abstract_bridge_node import AbstractBridgeNode
+
+
+class MujocoServicer:
+    def __init__(
+        self,
+        bridge_node: AbstractBridgeNode,
+        logger: rclpy.impl.rcutils_logger.RcutilsLogger,
+    ):
+        self.bridge_node = bridge_node
+        self.logger = logger
+
+    def register_to_server(self, server: grpc.Server):
+        self.logger.info("Registering 'MujocoServiceServicer' to server.")
+        add_MujocoServiceServicer_to_server(self, server)
+
+    def GetObjectsPoses(self, request: Empty, context: grpc.ServicerContext) -> MujocoObjectsPoses:
+        response = MujocoObjectsPoses()
+
+        for obj_name, pose_matrix in self.bridge_node.mujoco_objects_poses.items():
+            obj_pose = MujocoObjectPose()
+            obj_pose.name = obj_name
+            obj_pose.pose.pose.data.extend(pose_matrix.flatten())
+            response.poses.append(obj_pose)
+
+        return response

--- a/reachy_sdk_server/reachy_sdk_server/grpc_server/mujoco.py
+++ b/reachy_sdk_server/reachy_sdk_server/grpc_server/mujoco.py
@@ -1,19 +1,7 @@
-import os
-from typing import Iterator
-
 import grpc
 import rclpy
-import reachy2_sdk_api
-
 from google.protobuf.empty_pb2 import Empty
-from reachy2_sdk_api.reachy_pb2 import (
-    ReachyCoreMode,
-)
-from reachy2_sdk_api.mujoco_pb2 import (
-    MujocoObjectPose,
-    MujocoObjectsPoses,
-)
-
+from reachy2_sdk_api.mujoco_pb2 import MujocoObjectPose, MujocoObjectsPoses
 from reachy2_sdk_api.mujoco_pb2_grpc import add_MujocoServiceServicer_to_server
 
 from ..abstract_bridge_node import AbstractBridgeNode
@@ -38,7 +26,7 @@ class MujocoServicer:
         for obj_name, pose_matrix in self.bridge_node.mujoco_objects_poses.items():
             obj_pose = MujocoObjectPose()
             obj_pose.name = obj_name
-            obj_pose.pose.pose.data.extend(pose_matrix.flatten())
+            obj_pose.pose.data.extend(pose_matrix)
             response.poses.append(obj_pose)
 
         return response


### PR DESCRIPTION
**Goes with the SDK Client PR : https://github.com/pollen-robotics/reachy2-sdk/pull/553**

**Goes with branches:**
- [552 of reachy2-sdk](https://github.com/pollen-robotics/reachy2-sdk/tree/552-add-access-to-item-poses-in-mujoco-scenes)
- [188 of reachy2-sdk-api](https://github.com/pollen-robotics/reachy2-sdk-api/tree/188-add-access-to-item-poses-in-mujoco-scenes)
- [4 of reachy2_mujoco_assets](https://github.com/pollen-robotics/reachy2_mujoco_assets/tree/4-add-tracked-objects)

**Mujoco scenes side**:
Definition of the desired tracked bodies. 

**Server side:** 
- Addition of a subscriber to the `mujoco/item_position` topic, which updates a dictionary of poses for objects that are tracked continuously. 
- Addition of a Mujoco servicer, active only if the core_mode is Mujoco

**Client side:** 
- Added a Mujoco module if core_mode is Mujoco
- available via `reachy.mujoco`
- Three functions: 
  - one to obtain the entire dictionary of tracked object poses
  - one to obtain a specific object
  - one to obtain the relative pose of an object in Reachy's frame
  
  To test it, you can launch with fruits scene : 
 ```bash
  reset; ros2 launch reachy_bringup reachy.launch.py start_sdk_server:=true start_rviz:=true fake:=true mujoco:=true scene:=fruits
```
then check `reachy.mujoco.get_objects_poses()`, `reachy.mujoco.get_object_pose('orange1')` and `reachy.mujoco.get_relative_object_pose('orange1')`